### PR TITLE
move QFixListAltOpen() definition to plugin

### DIFF
--- a/autoload/unite/sources/qfixhowm.vim
+++ b/autoload/unite/sources/qfixhowm.vim
@@ -31,14 +31,6 @@ function! s:source.gather_candidates(args, context)
 endfunction
 
 
-
-if !exists("*QFixListAltOpen")
-	function! QFixListAltOpen(qflist, dir)
-		return a:qflist
-	endfunction
-endif
-
-
 let s:source_new = {
 \	"name" : "qfixhowm/new",
 \	"description" : "qfixhowm new",

--- a/plugin/qfixhowm.vim
+++ b/plugin/qfixhowm.vim
@@ -1,0 +1,5 @@
+if !exists("*QFixListAltOpen")
+	function! QFixListAltOpen(qflist, dir)
+		return a:qflist
+	endfunction
+endif


### PR DESCRIPTION
以下のような2つコマンドについて、A→Bの順で実行したときはうまく行き、B→Aの順で実行したときは以下のエラーが出て失敗します。
- A: `Unite qfixhowm`
- B: `<Leader>m` （など、何らかのメモリストを出すマッピング）

```
function <SNR>163_call_unite_empty..unite#start..unite#start#standard..unite#candidates#_recache..<SNR>184_recache_candidates_loop..<SNR>184_get_source_candidates..56, 行 13
Vim(return):E712: map() の引数はリスト型または辞書型でなければなりません
[unite.vim] Error occurred in gather_candidates!
[unite.vim] Source name is qfixhowm
```

よくよく調べてみると、これは `QFixListAltOpen()` の定義場所に依るようです。`QFixListAltOpen()` は上記プラグインのうち次の2箇所で定義されています。
- C: `autoload/unite/sources/qfixhowm.vim`
  
  ``` vim
  " a:qflist を返す
  if !exists("*QFixListAltOpen")
    function! QFixListAltOpen(qflist, dir)
        return a:qflist
    endfunction
  endif
  ```
- D: `autoload/qfixlist.vim`
  
  ``` vim
  " 何も返さない！
  if !exists('*QFixListAltOpen')
  function QFixListAltOpen(qflist, dir)
  endfunction
  endif
  ```

A→Bの順で実行したときは A を実行した時点で C→D の順に評価され、 C 内の`QFixListAltOpen()` が有効になります。

対して、B→A の順で実行したときは、B を実行した時点で D が評価されるものの、 C は評価されません。その後 A を実行した時点では D 内の `QFixListAltOpen()` が有効なため、 C 独自の `QFixListAltOpen()` は定義されず、そのため、上記エラーで落ちるようです。

これに対処するためには、 `autoload` ではなく `plugin` にて、 `QFixListAltOpen()` を定義する必要があります。本パッチを適用したところ、 A→B, B→A どちらでも動作するようになりました。
